### PR TITLE
Suppress warnings on Perl-5.18

### DIFF
--- a/lib/Test/LocalFunctions/Util.pm
+++ b/lib/Test/LocalFunctions/Util.pm
@@ -13,7 +13,8 @@ sub list_local_functions {
 
     no strict 'refs';
     load $module;
-    while ( my ( $key, $value ) = each %{"${module}::"} ) {
+    my %package = %{"${module}::"};
+    while ( my ( $key, $value ) = each %package ) {
         next unless $key =~ /^_/;
         next unless *{"${module}::${key}"}{CODE};
         next unless $module eq stash_name( $module->can($key) );


### PR DESCRIPTION
I got many warnings like "Use of each() on hash after insertion without
resetting hash iterator results in undefined behavior".

This problem is same as following URL.
- https://github.com/tokuhirom/Module-Functions/pull/2

Please see this patch.
